### PR TITLE
Migration utilities from cybersyn => cybersyn2 (/cs2-migrate)

### DIFF
--- a/mods/cybersyn2/control.lua
+++ b/mods/cybersyn2/control.lua
@@ -19,6 +19,7 @@ require("scripts.settings")
 require("scripts.lib")
 require("scripts.threads")
 require("scripts.alerts")
+require("scripts.migration")
 
 require("scripts.logistics.inventory")
 require("scripts.logistics.delivery.base")

--- a/mods/cybersyn2/lib/types.lua
+++ b/mods/cybersyn2/lib/types.lua
@@ -31,12 +31,26 @@ local lib = {}
 ---@class Cybersyn.Combinator.Ephemeral
 ---@field public entity? LuaEntity The primary entity of the combinator OR its ghost.
 
+---@enum Cybersyn.CombinatorMode
+lib.CombinatorMode = {
+	Station = "station",
+	DT = "dt",
+	Channels = "channels",
+	Prio = "prio",
+	AllowList = "allow-list",
+	Manifest = "manifest",
+	Wagon = "wagon",
+	WagonContents = "wagon-contents",
+	SharedInventory = "shared-inventory",
+	Inventory = "inventory",
+}
+
 ---An opaque reference to a fully realized and built combinator that has been indexed by Cybersyn and tracked in game state.
 ---@class Cybersyn.Combinator: Cybersyn.Combinator.Ephemeral
 ---@field public id UnitNumber The unique unit number of the combinator entity.
 ---@field public node_id? uint The id of the node this combinator is associated with, if any.
 ---@field public is_being_destroyed true? `true` if the combinator is being removed from state at this time.
----@field public mode? string The mode value set on this combinator, if known. Cached for performance reasons.
+---@field public mode? Cybersyn.CombinatorMode The mode value set on this combinator, if known. Cached for performance reasons.
 ---@field public inputs? SignalCounts The most recent signals read from the combinator. This is a cached value and will be `nil` in various situations where the combinator hasn't been or can't be read.
 ---@field public associated_entities table<string, LuaEntity>? Hidden or related entities that must be created or destroyed along with the combinator.
 ---@field public connected_rail LuaEntity? If this combinator was built next to a rail, this is that rail.

--- a/mods/cybersyn2/locale/en/base.cfg
+++ b/mods/cybersyn2/locale/en/base.cfg
@@ -50,6 +50,7 @@ reset-command-help=Reset Cybersyn's internal state and attempt to rebuild it fro
 force-reset-command-help=Force an internal state reset even when not recommended. [color=red]WARNING: force resetting with deliveries in progress will break things![/color]
 debugger-command-help=Open the Cybersyn debugger window.
 log-all-command-help=Log all Cybersyn strace messages to the console. This will create a lot of output, and is not recommended for normal use.
+migrate-command-help=Migrate from cybersyn to cybersyn2
 
 [cybersyn2-gui]
 signal=Signal

--- a/mods/cybersyn2/scripts/combinator/modes/channels.lua
+++ b/mods/cybersyn2/scripts/combinator/modes/channels.lua
@@ -2,6 +2,7 @@
 -- Channels combinator
 --------------------------------------------------------------------------------
 
+local types = require("__cybersyn2__.lib.types")
 local tlib = require("__cybersyn2__.lib.table")
 local relm = require("__cybersyn2__.lib.relm")
 local ultros = require("__cybersyn2__.lib.ultros")
@@ -57,7 +58,7 @@ relm.define_element({
 --------------------------------------------------------------------------------
 
 cs2.register_combinator_mode({
-	name = "channels",
+	name = types.CombinatorMode.Channels,
 	localized_string = "cybersyn2-combinator-modes.channels",
 	settings_element = "CombinatorGui.Mode.Channels",
 	help_element = "CombinatorGui.Mode.Channels.Help",

--- a/mods/cybersyn2/scripts/combinator/modes/dt.lua
+++ b/mods/cybersyn2/scripts/combinator/modes/dt.lua
@@ -2,6 +2,7 @@
 -- DT combinator
 --------------------------------------------------------------------------------
 
+local types = require("__cybersyn2__.lib.types")
 local tlib = require("__cybersyn2__.lib.table")
 local relm = require("__cybersyn2__.lib.relm")
 local ultros = require("__cybersyn2__.lib.ultros")
@@ -96,7 +97,7 @@ relm.define_element({
 --------------------------------------------------------------------------------
 
 cs2.register_combinator_mode({
-	name = "dt",
+	name = types.CombinatorMode.DT,
 	localized_string = "cybersyn2-combinator-modes.dt",
 	settings_element = "CombinatorGui.Mode.DT",
 	help_element = "CombinatorGui.Mode.DT.Help",

--- a/mods/cybersyn2/scripts/combinator/modes/inventory.lua
+++ b/mods/cybersyn2/scripts/combinator/modes/inventory.lua
@@ -2,6 +2,7 @@
 -- Inventory input combinator
 --------------------------------------------------------------------------------
 
+local types = require("__cybersyn2__.lib.types")
 local tlib = require("__cybersyn2__.lib.table")
 local relm = require("__cybersyn2__.lib.relm")
 local ultros = require("__cybersyn2__.lib.ultros")
@@ -117,7 +118,7 @@ relm.define_element({
 --------------------------------------------------------------------------------
 
 cs2.register_combinator_mode({
-	name = "inventory",
+	name = types.CombinatorMode.Inventory,
 	localized_string = "cybersyn2-combinator-modes.inventory",
 	settings_element = "CombinatorGui.Mode.Inventory",
 	help_element = "CombinatorGui.Mode.Inventory.Help",
@@ -132,7 +133,7 @@ cs2.register_combinator_mode({
 local function check_true_inventory_mode(stop) stop:update_inventory_mode() end
 
 cs2.on_combinator_node_associated(function(comb, new, prev)
-	if comb.mode == "inventory" then
+	if comb.mode == types.CombinatorMode.Inventory then
 		if new then check_true_inventory_mode(new) end
 		if prev then check_true_inventory_mode(prev) end
 	end
@@ -141,7 +142,7 @@ end)
 cs2.on_combinator_setting_changed(function(comb, setting, new, prev)
 	if
 		setting == nil
-		or (setting == "mode" and (new == "inventory" or prev == "inventory"))
+		or (setting == "mode" and (new == types.CombinatorMode.Inventory or prev == types.CombinatorMode.Inventory))
 	then
 		local stop = comb:get_node("stop") --[[@as Cybersyn.TrainStop?]]
 		if stop then check_true_inventory_mode(stop) end

--- a/mods/cybersyn2/scripts/combinator/modes/manifest.lua
+++ b/mods/cybersyn2/scripts/combinator/modes/manifest.lua
@@ -2,6 +2,7 @@
 -- Manifest output combinator
 --------------------------------------------------------------------------------
 
+local types = require("__cybersyn2__.lib.types")
 local tlib = require("__cybersyn2__.lib.table")
 local relm = require("__cybersyn2__.lib.relm")
 local ultros = require("__cybersyn2__.lib.ultros")
@@ -101,7 +102,7 @@ relm.define_element({
 --------------------------------------------------------------------------------
 
 cs2.register_combinator_mode({
-	name = "manifest",
+	name = types.CombinatorMode.Manifest,
 	localized_string = "cybersyn2-combinator-modes.manifest",
 	settings_element = "CombinatorGui.Mode.Manifest",
 	help_element = "CombinatorGui.Mode.Manifest.Help",
@@ -121,7 +122,7 @@ cs2.on_train_arrived(function(train, cstrain, stop)
 
 	-- Get train combs.
 	local combs = stop:get_associated_combinators(
-		function(c) return c.mode == "manifest" end
+		function(c) return c.mode == types.CombinatorMode.Manifest end
 	)
 	if not combs or #combs == 0 then return end
 
@@ -163,7 +164,7 @@ cs2.on_train_departed(function(train, cstrain, stop)
 	if not cstrain or not stop then return end
 	-- On train departure, clear all manifest combs.
 	local combs = stop:get_associated_combinators(
-		function(c) return c.mode == "manifest" end
+		function(c) return c.mode == types.CombinatorMode.Manifest end
 	)
 	if #combs > 0 then
 		local empty = {}

--- a/mods/cybersyn2/scripts/combinator/modes/prio.lua
+++ b/mods/cybersyn2/scripts/combinator/modes/prio.lua
@@ -2,6 +2,7 @@
 -- Prio combinator
 --------------------------------------------------------------------------------
 
+local types = require("__cybersyn2__.lib.types")
 local tlib = require("__cybersyn2__.lib.table")
 local relm = require("__cybersyn2__.lib.relm")
 local ultros = require("__cybersyn2__.lib.ultros")
@@ -57,7 +58,7 @@ relm.define_element({
 --------------------------------------------------------------------------------
 
 cs2.register_combinator_mode({
-	name = "prio",
+	name = types.CombinatorMode.Prio,
 	localized_string = "cybersyn2-combinator-modes.prio",
 	settings_element = "CombinatorGui.Mode.Prio",
 	help_element = "CombinatorGui.Mode.Prio.Help",

--- a/mods/cybersyn2/scripts/combinator/modes/shared-inventory.lua
+++ b/mods/cybersyn2/scripts/combinator/modes/shared-inventory.lua
@@ -2,6 +2,7 @@
 -- Shared inventory combinator
 --------------------------------------------------------------------------------
 
+local types = require("__cybersyn2__.lib.types")
 local tlib = require("__cybersyn2__.lib.table")
 local mlib = require("__cybersyn2__.lib.math")
 local relm = require("__cybersyn2__.lib.relm")
@@ -131,7 +132,7 @@ relm.define_element({
 --------------------------------------------------------------------------------
 
 cs2.register_combinator_mode({
-	name = "shared-inventory",
+	name = types.CombinatorMode.SharedInventory,
 	localized_string = "cybersyn2-combinator-modes.shared-inventory",
 	settings_element = "CombinatorGui.Mode.SharedInventory",
 	help_element = "CombinatorGui.Mode.SharedInventory.Help",
@@ -204,7 +205,7 @@ local function render_connection(player)
 	local source_combinator = cs2.get_combinator(csun)
 	local selected_combinator =
 		cs2.get_combinator(player.selected and player.selected.unit_number or nil)
-	if selected_combinator and selected_combinator.mode ~= "shared-inventory" then
+	if selected_combinator and selected_combinator.mode ~= types.CombinatorMode.SharedInventory then
 		selected_combinator = nil
 	end
 
@@ -216,7 +217,7 @@ local function render_connection(player)
 				local slave_stop = cs2.get_stop(slave_id)
 				if slave_stop then
 					local slave_combinator =
-						slave_stop:get_combinator_with_mode("shared-inventory")
+						slave_stop:get_combinator_with_mode(types.CombinatorMode.SharedInventory)
 					if slave_combinator then
 						draw_connection(
 							objects,
@@ -233,7 +234,7 @@ local function render_connection(player)
 			local master_stop = cs2.get_stop(stop.shared_inventory_master)
 			if master_stop then
 				local master_combinator =
-					master_stop:get_combinator_with_mode("shared-inventory")
+					master_stop:get_combinator_with_mode(types.CombinatorMode.SharedInventory)
 				if master_combinator then
 					draw_connection(
 						objects,
@@ -293,7 +294,7 @@ local function finish_connection(player, entity)
 		or nil
 	local source_combinator = cs2.get_combinator(csun)
 	if
-		not source_combinator or (source_combinator.mode ~= "shared-inventory")
+		not source_combinator or (source_combinator.mode ~= types.CombinatorMode.SharedInventory)
 	then
 		return
 	end
@@ -301,7 +302,7 @@ local function finish_connection(player, entity)
 	if not source_stop then return end
 
 	local target_combinator = cs2.get_combinator(entity.unit_number)
-	if not target_combinator or target_combinator.mode ~= "shared-inventory" then
+	if not target_combinator or target_combinator.mode ~= types.CombinatorMode.SharedInventory then
 		cs2_lib.flying_text(
 			player,
 			"Not a shared inventory combinator",
@@ -392,7 +393,7 @@ end
 
 ---@param stop Cybersyn.TrainStop
 local function stop_to_shared_inventory_comb_unit_number(stop)
-	local combinator = stop:get_combinator_with_mode("shared-inventory")
+	local combinator = stop:get_combinator_with_mode(types.CombinatorMode.SharedInventory)
 	if not combinator then return nil end
 	return combinator.entity.unit_number
 end
@@ -406,7 +407,7 @@ cs2.on_blueprint_setup(function(bpinfo)
 	local bp_to_comb = {}
 	for bp_index, entity in pairs(bp_to_world) do
 		local combinator = cs2.get_combinator(entity.unit_number, true)
-		if combinator and combinator.mode == "shared-inventory" then
+		if combinator and combinator.mode == types.CombinatorMode.SharedInventory then
 			bp_to_comb[bp_index] = combinator
 			un_to_bp[entity.unit_number] = bp_index
 		end
@@ -456,7 +457,7 @@ cs2.on_blueprint_built(function(bpinfo)
 	if not bp_entities then return end
 	local shared_inventory_combinators = {}
 	for ei, entity in pairs(bp_entities) do
-		if entity.tags and entity.tags.mode == "shared-inventory" then
+		if entity.tags and entity.tags.mode == types.CombinatorMode.SharedInventory then
 			shared_inventory_combinators[ei] = entity
 		end
 	end
@@ -574,13 +575,13 @@ local function try_identify(combinator_entity)
 end
 
 cs2.on_combinator_created(function(combinator)
-	if combinator.mode ~= "shared-inventory" then return end
+	if combinator.mode ~= types.CombinatorMode.SharedInventory then return end
 	try_identify(combinator.entity)
 	try_relink()
 end)
 
 cs2.on_node_combinator_set_changed(function(node)
-	local si_comb = node:get_combinator_with_mode("shared-inventory")
+	local si_comb = node:get_combinator_with_mode(types.CombinatorMode.SharedInventory)
 	if not si_comb then return end
 	try_relink()
 end)
@@ -595,13 +596,13 @@ cs2.on_reset(function(reset_data)
 			---@cast master Cybersyn.TrainStop
 			local slaves = master.shared_inventory_slaves
 			if slaves then
-				local master_comb = master:get_combinator_with_mode("shared-inventory")
+				local master_comb = master:get_combinator_with_mode(types.CombinatorMode.SharedInventory)
 				if not master_comb then goto continue end
 				for slave_id in pairs(slaves) do
 					local slave_stop = cs2.get_stop(slave_id)
 					if slave_stop then
 						local slave_comb =
-							slave_stop:get_combinator_with_mode("shared-inventory")
+							slave_stop:get_combinator_with_mode(types.CombinatorMode.SharedInventory)
 						if slave_comb then
 							inventory_links[#inventory_links + 1] = {
 								game.tick,

--- a/mods/cybersyn2/scripts/combinator/modes/station.lua
+++ b/mods/cybersyn2/scripts/combinator/modes/station.lua
@@ -2,6 +2,7 @@
 -- Station combinator.
 --------------------------------------------------------------------------------
 
+local types = require("__cybersyn2__.lib.types")
 local relm = require("__cybersyn2__.lib.relm")
 local ultros = require("__cybersyn2__.lib.ultros")
 local cs2 = _G.cs2
@@ -279,7 +280,7 @@ relm.define_element({
 --------------------------------------------------------------------------------
 
 cs2.register_combinator_mode({
-	name = "station",
+	name = types.CombinatorMode.Station,
 	localized_string = "cybersyn2-combinator-modes.station",
 	settings_element = "CombinatorGui.Mode.Station",
 	help_element = "CombinatorGui.Mode.Station.Help",

--- a/mods/cybersyn2/scripts/combinator/modes/wagon.lua
+++ b/mods/cybersyn2/scripts/combinator/modes/wagon.lua
@@ -2,6 +2,7 @@
 -- Wagon manifest, formerly known as "wagon control"
 --------------------------------------------------------------------------------
 
+local types = require("__cybersyn2__.lib.types")
 local tlib = require("__cybersyn2__.lib.table")
 local relm = require("__cybersyn2__.lib.relm")
 local ultros = require("__cybersyn2__.lib.ultros")
@@ -99,7 +100,7 @@ relm.define_element({
 --------------------------------------------------------------------------------
 
 cs2.register_combinator_mode({
-	name = "wagon",
+	name = types.CombinatorMode.Wagon,
 	localized_string = "cybersyn2-combinator-modes.wagon",
 	settings_element = "CombinatorGui.Mode.Wagon",
 	help_element = "CombinatorGui.Mode.Wagon.Help",
@@ -120,7 +121,7 @@ local SCRIPT = defines.wire_origin.script
 ---@param force_destroy boolean?
 local function create_or_destroy_hidden_chest(combinator, force_destroy)
 	if
-		combinator.mode == "wagon"
+		combinator.mode == types.CombinatorMode.Wagon
 		and combinator:read_setting(combinator_settings.live_wagon_inventory)
 		and not force_destroy
 	then
@@ -190,7 +191,7 @@ end
 ---@param stop Cybersyn.TrainStop
 local function check_per_wagon_mode(stop)
 	local combs = stop:get_associated_combinators(
-		function(c) return c.mode == "wagon" end
+		function(c) return c.mode == types.CombinatorMode.Wagon end
 	)
 	local is_per_wagon = false
 	for _, comb in pairs(combs) do
@@ -216,7 +217,7 @@ end
 cs2.on_combinator_created(create_or_destroy_hidden_chest)
 
 cs2.on_combinator_node_associated(function(comb, new, prev)
-	if comb.mode == "wagon" then
+	if comb.mode == types.CombinatorMode.Wagon then
 		if new then check_per_wagon_mode(new) end
 		if prev then check_per_wagon_mode(prev) end
 	end
@@ -225,7 +226,7 @@ end)
 cs2.on_combinator_setting_changed(function(combinator, setting, new, prev)
 	if
 		setting == nil
-		or (setting == "mode" and (new == "wagon" or prev == "wagon"))
+		or (setting == "mode" and (new == types.CombinatorMode.Wagon or prev == types.CombinatorMode.Wagon))
 		or setting == "live_wagon_inventory"
 	then
 		local stop = combinator:get_node("stop") --[[@as Cybersyn.TrainStop?]]
@@ -242,7 +243,7 @@ cs2.on_combinator_destroyed(
 cs2.on_train_departed(function(train, cstrain, stop)
 	if not cstrain or not stop then return end
 	local combs = stop:get_associated_combinators(
-		function(c) return c.mode == "wagon" end
+		function(c) return c.mode == types.CombinatorMode.Wagon end
 	)
 	if #combs > 0 then
 		for _, comb in pairs(combs) do
@@ -583,7 +584,7 @@ end
 ---@param delivery Cybersyn.TrainDelivery
 local function set_producer_wagon_combs(cstrain, stop, delivery)
 	local combs = stop:get_associated_combinators(
-		function(c) return c.mode == "wagon" end
+		function(c) return c.mode == types.CombinatorMode.Wagon end
 	)
 	if #combs == 0 then return end
 	local manifests = create_wagon_manifests(cstrain, stop, delivery)
@@ -604,7 +605,7 @@ end
 ---@param delivery Cybersyn.TrainDelivery
 local function set_consumer_wagon_combs(cstrain, stop, delivery)
 	local combs = stop:get_associated_combinators(
-		function(c) return c.mode == "wagon" end
+		function(c) return c.mode == types.CombinatorMode.Wagon end
 	)
 	if #combs == 0 then return end
 	for _, comb in pairs(combs) do

--- a/mods/cybersyn2/scripts/commands.lua
+++ b/mods/cybersyn2/scripts/commands.lua
@@ -21,3 +21,13 @@ commands.add_command(
 	{ "cybersyn2-commands.log-all-command-help" },
 	function() cs2.debug.set_strace(0, 0, nil) end
 )
+
+commands.add_command(
+	"cs2-migrate",
+	"cybersyn2-commands.migrate-command-help",
+	function(command)
+		-- Perform migration
+		cs2.migrate_from_cybersyn()
+		game.print("Migration from Cybersyn to Cybersyn2 completed")
+	end
+)

--- a/mods/cybersyn2/scripts/constants.lua
+++ b/mods/cybersyn2/scripts/constants.lua
@@ -1,6 +1,7 @@
 --------------------------------------------------------------------------------
 -- Global constants
 --------------------------------------------------------------------------------
+local types = require("__cybersyn2__.lib.types")
 
 _G.cs2.CYBERSYN_TRAIN_GROUP_NAME_PREFIX = "[virtual-signal=cybersyn2]"
 _G.cs2.WINDOW_NAME = "cybersyn2-combinator-gui"
@@ -53,7 +54,7 @@ _G.cs2.CONFIGURATION_VIRTUAL_SIGNAL_SET = {
 
 -- Default settings for a newly placed combinator with no tags.
 _G.cs2.DEFAULT_COMBINATOR_SETTINGS = {
-	mode = "station",
+	mode = types.CombinatorMode.Station,
 	network = "signal-A",
 	pr = 0,
 	inactivity_mode = 0,

--- a/mods/cybersyn2/scripts/logistics/thread/poll-nodes.lua
+++ b/mods/cybersyn2/scripts/logistics/thread/poll-nodes.lua
@@ -4,6 +4,7 @@
 -- inputs and adding their items to the logistics arrays.
 --------------------------------------------------------------------------------
 
+local types = require("__cybersyn2__.lib.types")
 local stlib = require("__cybersyn2__.lib.strace")
 local tlib = require("__cybersyn2__.lib.table")
 local slib = require("__cybersyn2__.lib.signal")
@@ -103,7 +104,7 @@ end
 ---@param stop Cybersyn.TrainStop
 function LogisticsThread:poll_train_stop_station_comb(stop)
 	local combs = stop:get_associated_combinators(
-		function(comb) return comb.mode == "station" end
+		function(comb) return comb.mode == types.CombinatorMode.Station end
 	)
 	local is_valid = stop:is_valid()
 	if #combs == 0 and is_valid then
@@ -169,8 +170,12 @@ function LogisticsThread:poll_train_stop_station_comb(stop)
 	end
 	for k, v in pairs(inputs) do
 		if slib.key_is_virtual(k) then
-			if k == "cybersyn2-priority" then
+			if k == "cybersyn2-priority" or k == "cybersyn-priority" then
 				stop.priority = v
+			elseif k == "cybersyn-request-threshold" then
+				stop.threshold_item_in = v
+			elseif k == "cybersyn-fluid-request-threshold" then
+				stop.threshold_fluid_in = v
 			elseif k == "cybersyn2-all-items" then
 				stop.threshold_item_in = v
 				stop.threshold_item_out = v
@@ -226,7 +231,7 @@ function LogisticsThread:poll_dt_combs(stop)
 	stop.thresholds_in = nil
 	stop.thresholds_out = nil
 	local combs = stop:get_associated_combinators(
-		function(comb) return comb.mode == "dt" end
+		function(comb) return comb.mode == types.CombinatorMode.DT end
 	)
 	if #combs == 0 then return end
 	local thresholds_in = nil
@@ -263,7 +268,7 @@ end
 function LogisticsThread:poll_prio_combs(stop)
 	stop.priorities = nil
 	local combs = stop:get_associated_combinators(
-		function(comb) return comb.mode == "prio" end
+		function(comb) return comb.mode == types.CombinatorMode.Prio end
 	)
 	if #combs == 0 then return end
 	local priorities = nil
@@ -289,7 +294,7 @@ function LogisticsThread:poll_channels_combs(stop)
 	stop.channel = nil
 	-- Reread combs
 	local combs = stop:get_associated_combinators(
-		function(comb) return comb.mode == "channels" end
+		function(comb) return comb.mode == types.CombinatorMode.Channels end
 	)
 	if #combs == 0 then return end
 	local channels = nil

--- a/mods/cybersyn2/scripts/migration.lua
+++ b/mods/cybersyn2/scripts/migration.lua
@@ -1,0 +1,374 @@
+--------------------------------------------------------------------------------
+-- Migration script from Cybersyn to Cybersyn2
+--------------------------------------------------------------------------------
+
+local types = require("__cybersyn2__.lib.types")
+local cs2 = _G.cs2
+
+-- Cybersyn combinator operation modes
+local MODE_PRIMARY_IO = "/"
+local MODE_PRIMARY_IO_FAILED_REQUEST = "^"
+local MODE_PRIMARY_IO_ACTIVE = "<<"
+local MODE_SECONDARY_IO = "%"
+local MODE_DEPOT = "+"
+local MODE_WAGON = "-"
+local MODE_REFUELER = ">>"
+
+-- Cybersyn settings
+local SETTING_DISABLE_ALLOW_LIST = 2
+local SETTING_IS_STACK = 3
+local SETTING_ENABLE_INACTIVE = 4
+local SETTING_USE_ANY_DEPOT = 5
+local SETTING_DISABLE_DEPOT_BYPASS = 6
+local SETTING_ENABLE_SLOT_BARRING = 7
+local SETTING_ENABLE_CIRCUIT_CONDITION = 8
+local SETTING_ENABLE_TRAIN_COUNT = 9
+local SETTING_ENABLE_MANUAL_INVENTORY = 10
+local SETTING_DISABLE_MANIFEST_CONDITION = 11
+
+-- Signal for locked slots in cybersyn
+local LOCKED_SLOTS = "cybersyn-locked-slots"
+local LOCKED_FLUID = "cybersyn-reserved-fluid-capacity"
+
+local function get_front_position(entity)
+    local pos = entity.position
+    local dir = entity.direction
+
+    if dir == defines.direction.north then
+        return {x = pos.x, y = pos.y - 0.5}
+    elseif dir == defines.direction.east then
+        return {x = pos.x + 0.5, y = pos.y}
+    elseif dir == defines.direction.south then
+        return {x = pos.x, y = pos.y + 0.5}
+    elseif dir == defines.direction.west then
+        return {x = pos.x - 0.5, y = pos.y}
+    end
+end
+
+local function get_back_position(entity)
+    local pos = entity.position
+    local dir = entity.direction
+
+    if dir == defines.direction.north then
+        return {x = pos.x, y = pos.y + 0.5}
+    elseif dir == defines.direction.east then
+        return {x = pos.x - 0.5, y = pos.y}
+    elseif dir == defines.direction.south then
+        return {x = pos.x, y = pos.y - 0.5}
+    elseif dir == defines.direction.west then
+        return {x = pos.x + 0.5, y = pos.y}
+    end
+end
+
+local function flip_direction(direction)
+    if direction == defines.direction.north then
+        return defines.direction.south
+    elseif direction == defines.direction.south then
+        return defines.direction.north
+    elseif direction == defines.direction.east then
+        return defines.direction.west
+    elseif direction == defines.direction.west then
+        return defines.direction.east
+    end
+end
+
+---@param entity LuaEntity
+---@return LuaEntity?
+local function find_nearby_station(entity)
+    local pos = entity.position
+    local search_area = {
+        { pos.x - 2, pos.y - 2 },
+        { pos.x + 2, pos.y + 2 },
+    }
+
+    local nearby_stations = entity.surface.find_entities_filtered{
+        name = "train-stop",
+        area = search_area
+    }
+
+    if #nearby_stations == 0 then
+        -- No station found nearby
+        return nil
+    end
+
+    return nearby_stations[1]
+end
+
+local function find_input_signal(entity, signal_name)
+    local networks = {
+        defines.wire_connector_id.combinator_input_red,
+        defines.wire_connector_id.combinator_input_green
+    }
+
+    for _, network_id in pairs(networks) do
+        local network = entity.get_circuit_network(network_id)
+        if network then
+            -- Check if the locked slots signal is present
+            local signals = network.signals
+            if signals then
+                for _, signal in pairs(signals) do
+                    if signal.signal and signal.signal.name == signal_name and signal.signal.type == "virtual" then
+                        return signal.count
+                    end
+                end
+            end
+        end
+    end
+end
+
+-- Convert from cybersyn combinator to cybersyn2 combinator
+---@param old_entity LuaEntity
+local function convert_combinator(old_entity)
+    -- Skip if entity is not valid
+    if not (old_entity and old_entity.valid) then
+        return nil
+    end
+
+    -- Get combinator's control behavior
+    local control_behavior = old_entity.get_control_behavior() --[[@as LuaArithmeticCombinatorControlBehavior]]
+    if not control_behavior then
+        return nil
+    end
+
+    -- Get position and surface for new combinator
+    local position = old_entity.position
+    local surface = old_entity.surface
+    local direction = old_entity.direction
+    local force = old_entity.force
+
+    -- Get operation mode (if it exists)
+    local op = control_behavior.parameters.operation
+    if not op then
+        -- Log that we couldn't find an operation parameter
+        game.print("Warning: Could not find operation parameter for combinator at " ..
+                   position.x .. "," .. position.y)
+        return nil
+    end
+
+    local config = control_behavior.parameters.second_constant or 0
+    local network_signal = control_behavior.parameters.first_signal and control_behavior.parameters.first_signal.name or "signal-A"
+
+    if op == MODE_PRIMARY_IO or op == MODE_PRIMARY_IO_FAILED_REQUEST or op == MODE_PRIMARY_IO_ACTIVE then
+        return create_station(old_entity, network_signal, config)
+    elseif op == MODE_DEPOT then
+        return create_depot(old_entity, config)
+    elseif op == MODE_REFUELER then
+        old_entity.destroy()
+        -- User will need to manually create a refueler
+    end
+end
+
+function create_station(old_entity, network_signal, config)
+    local position = old_entity.position
+    local surface = old_entity.surface
+    local direction = old_entity.direction
+    local force = old_entity.force
+
+    -- Check if this entity has the locked slots signal connected
+    local locked_slots_value = find_input_signal(old_entity, LOCKED_SLOTS) or 0
+    local locked_fluid_value = find_input_signal(old_entity, LOCKED_FLUID) or 0
+
+    local connections = {}
+    local create_train_connector = false
+    for _, connector in pairs(old_entity.get_wire_connectors(false)) do
+        for _, wire in ipairs(connector.connections) do
+            if wire.origin == defines.wire_origin.player then
+                if connector.wire_connector_id == defines.wire_connector_id.combinator_output_green or
+                    connector.wire_connector_id == defines.wire_connector_id.combinator_output_red then
+                    create_train_connector = true
+                end
+                table.insert(connections, {
+                    wire_connector_id = connector.wire_connector_id,
+                    wire_type = connector.wire_type,
+                    target_entity = wire.target.owner,
+                    target_connector_id = wire.target.wire_connector_id
+                })
+            end
+        end
+    end
+
+    -- Create new cybersyn2 combinator with error handling
+    local new_entity = surface.create_entity{
+        name = "cybersyn2-combinator",
+        position = get_front_position(old_entity),
+        direction = flip_direction(direction),
+        force = force,
+        fast_replace = false,
+        create_build_effect_smoke = true,
+        raise_built = true
+    }
+
+    if not new_entity then
+        return false
+    end
+
+    local new_train_comb_entity = nil
+    if create_train_connector then
+        new_train_comb_entity = surface.create_entity{
+            name = "cybersyn2-combinator",
+            position = get_back_position(old_entity),
+            direction = flip_direction(direction),
+            force = force,
+            fast_replace = false,
+            create_build_effect_smoke = true,
+            raise_built = true
+        }
+
+        if not new_train_comb_entity then
+            game.print("Warning: Failed to create train connector for combinator at " ..
+                       position.x .. "," .. position.y)
+            return false
+        end
+
+        local new_train_combinator = cs2.EphemeralCombinator.new(new_train_comb_entity)
+        if new_train_combinator then
+           new_train_combinator:write_setting(cs2.combinator_settings.mode, types.CombinatorMode.Manifest)
+        end
+    end
+
+    -- Handle circuit connections
+    local mapped_connections = {
+        [defines.wire_connector_id.combinator_input_red] = {
+            entity = new_entity,
+            wire_connector_id = defines.wire_connector_id.combinator_output_red,
+        },
+        [defines.wire_connector_id.combinator_input_green] = {
+            entity = new_entity,
+            wire_connector_id = defines.wire_connector_id.combinator_output_green,
+        },
+        [defines.wire_connector_id.combinator_output_red] = {
+            entity = new_train_comb_entity,
+            wire_connector_id = defines.wire_connector_id.combinator_output_red,
+        },
+        [defines.wire_connector_id.combinator_output_green] = {
+            entity = new_train_comb_entity,
+            wire_connector_id = defines.wire_connector_id.combinator_output_green,
+        },
+    }
+
+    for _, conn in pairs(connections) do
+        local new_conn = mapped_connections[conn.wire_connector_id]
+        if new_conn then
+            local new_connector    = new_conn.entity.get_wire_connector(new_conn.wire_connector_id)
+            local target_connector = conn.target_entity.get_wire_connector(conn.target_connector_id)
+            new_connector.connect_to(target_connector, false, defines.wire_origin.player)
+        end
+    end
+
+    -- Create an ephemeral combinator reference
+    local new_combinator = cs2.EphemeralCombinator.new(new_entity)
+    if not new_combinator then
+        return false
+    end
+
+    local is_pr_state = bit32.extract(config, 0, 2)
+    -- Not supported ATM, needs another combinator to handle this
+	local allows_all_trains = bit32.extract(config, SETTING_DISABLE_ALLOW_LIST) > 0
+	local is_stack = bit32.extract(config, SETTING_IS_STACK) > 0
+	local enable_inactive = bit32.extract(config, SETTING_ENABLE_INACTIVE) > 0
+	local enable_circuit_condition = bit32.extract(config, SETTING_ENABLE_CIRCUIT_CONDITION) > 0
+	local disable_manifest_condition = bit32.extract(config, SETTING_DISABLE_MANIFEST_CONDITION) > 0
+
+    new_combinator:write_setting(cs2.combinator_settings.mode, cs2.MODE_STATION)
+    new_combinator:write_setting(cs2.combinator_settings.network_signal, network_signal)
+    new_combinator:write_setting(cs2.combinator_settings.pr, is_pr_state)
+
+    new_combinator:write_setting(cs2.combinator_settings.use_stack_thresholds, is_stack)
+
+    if enable_inactive then
+        new_combinator:write_setting(cs2.combinator_settings.inactivity_mode, 1)
+        new_combinator:write_setting(cs2.combinator_settings.inactivity_timeout, 1)
+    end
+
+    if enable_circuit_condition then
+        new_combinator:write_setting(cs2.combinator_settings.allow_departure_signal, {
+            type = "virtual",
+            name = "signal-check",
+        })
+    end
+
+    if disable_manifest_condition then
+        new_combinator:write_setting(cs2.combinator_settings.disable_cargo_condition, true)
+    end
+
+
+    if locked_slots_value > 0 then
+        local slots_set = new_combinator:write_setting(cs2.combinator_settings.reserved_slots, locked_slots_value)
+        if not slots_set then
+            game.print("Warning: Failed to set reserved slots for new combinator")
+        end
+    end
+
+    if locked_fluid_value > 0 then
+        local fluid_set = new_combinator:write_setting(cs2.combinator_settings.reserved_capacity, locked_fluid_value)
+        if not fluid_set then
+            game.print("Warning: Failed to set reserved fluid for new combinator")
+        end
+    end
+
+    if old_entity and old_entity.valid then
+        old_entity.destroy()
+    end
+
+    return true
+end
+
+function create_depot(old_entity, config)
+    -- Find connected trains to this depot, and add them to a train group
+    local train_stop = find_nearby_station(old_entity)
+    if train_stop then
+        for _, train in pairs(train_stop.get_train_stop_trains()) do
+            if train.group == "" then
+                train.group = "[virtual-signal=cybersyn2] Train"
+            end
+        end
+    end
+
+    -- Cybersyn2's depots are just regular train stops
+    old_entity.destroy()
+
+    return true
+end
+
+function _G.cs2.migrate_from_cybersyn()
+    if not script.active_mods["cybersyn"] then
+        game.print("Cybersyn mod is not active. Migration is not needed.")
+        return
+    end
+
+    local converted_count = 0
+    local failed_count = 0
+
+    --for _, player in pairs(game.players) do
+    --   local entity = player.selected
+    --   if entity and entity.valid and entity.name == "cybersyn-combinator" then
+    --       local new_entity = convert_combinator(entity)
+    --   else
+    --       game.print("No valid entity selected. Please select a Cybersyn combinator.")
+    --   end
+    --   return
+    --end
+
+    -- Process all surfaces
+    for _, surface in pairs(game.surfaces) do
+        local cybersyn_combinators = surface.find_entities_filtered{name = "cybersyn-combinator"}
+        
+        if cybersyn_combinators then
+            for _, combinator in pairs(cybersyn_combinators) do
+                local new_entity = convert_combinator(combinator)
+                if new_entity then
+                    converted_count = converted_count + 1
+                else
+                    failed_count = failed_count + 1
+                end
+            end
+        else
+            game.print("Error finding combinators on surface: " .. surface.name)
+        end
+    end
+
+    game.print("Migration complete: Converted " .. converted_count .. " Cybersyn combinators to Cybersyn2.")
+    if failed_count > 0 then
+        game.print("Warning: Failed to convert " .. failed_count .. " combinators.")
+    end
+end

--- a/mods/cybersyn2/scripts/node/base.lua
+++ b/mods/cybersyn2/scripts/node/base.lua
@@ -153,7 +153,7 @@ end
 
 ---Get the first combinator associated with this node and having the given
 ---mode.
----@param mode string
+---@param mode Cybersyn.CombinatorMode
 ---@return Cybersyn.Combinator? #A combinator with the given mode associated to this node, if any.
 function Node:get_combinator_with_mode(mode)
 	for id in pairs(self.combinator_set) do

--- a/mods/cybersyn2/scripts/node/stop/base.lua
+++ b/mods/cybersyn2/scripts/node/stop/base.lua
@@ -1,3 +1,4 @@
+local types = require("__cybersyn2__.lib.types")
 local class = require("__cybersyn2__.lib.class").class
 local mlib = require("__cybersyn2__.lib.math")
 local slib = require("__cybersyn2__.lib.signal")
@@ -354,7 +355,7 @@ function TrainStop:update_inventory_mode()
 		return
 	end
 
-	local inv_comb = self:get_combinator_with_mode("inventory")
+	local inv_comb = self:get_combinator_with_mode(types.CombinatorMode.Inventory)
 	if not inv_comb then
 		-- Pseudoinventory case
 		if not inv.is_pseudoinventory then
@@ -450,7 +451,7 @@ function TrainStop:update_inventory(is_opportunistic)
 	if not inventory.is_pseudoinventory then
 		-- True inventory mode; read from Inventory combs.
 		local combs = self:get_associated_combinators(
-			function(c) return c.mode == "inventory" end
+			function(c) return c.mode == types.CombinatorMode.Inventory end
 		)
 		local read_inventory = false
 		local read_provide = false
@@ -495,7 +496,7 @@ function TrainStop:update_inventory(is_opportunistic)
 	else
 		-- Pseudoinventory mode; read from station combinator.
 		local combs = self:get_associated_combinators(
-			function(c) return c.mode == "station" end
+			function(c) return c.mode == types.CombinatorMode.Station end
 		)
 		if #combs == 1 then
 			local comb = combs[1]


### PR DESCRIPTION
Some backwards compatibility for cs1 priority/request thresholds
Migrate Combinator Mode to enum