### PR TITLE
feat: Allow bidirectional coordinate stops

### DIFF
--- a/mods/cybersyn2/locale/en/base.cfg
+++ b/mods/cybersyn2/locale/en/base.cfg
@@ -31,6 +31,7 @@ cybersyn2-setting-default-auto-threshold-percent=Default depletion threshold per
 cybersyn2-setting-default-train-fullness-percent=Default train fullness percentage
 cybersyn2-setting-default-netmask=Default network mask
 cybersyn2-setting-shared-inventory-prefer-parallel=Prefer parallel routing for stops with shared inventory
+cybersyn2-setting-constrain-coordinate-stop-direction=Constraint coordinate stop direction
 
 [mod-setting-description]
 cybersyn2-setting-enable-logistics=Globally enable or disable logistics. If disabled, no deliveries will be scheduled.
@@ -46,6 +47,7 @@ cybersyn2-setting-default-auto-threshold-percent=The default percentage of the t
 cybersyn2-setting-default-train-fullness-percent=The default percentage of the total train cargo capacity that should be filled before a train will deliver an outstanding request.
 cybersyn2-setting-default-netmask=The default network mask to use when one is not provided as a signal.
 cybersyn2-setting-shared-inventory-prefer-parallel=When enabled, stations using the advanced shared inventory feature will receive only one delivery per loop cycle. This will cause trains to parallelize over all the shared stations rather than queueing up at a single station.\n\nIn very large bases, disabling this setting can improve throughput by allowing more deliveries to be scheduled per cycle, at the expense of a tendency for trains to queue at a single station.\n\nIt is recommended to leave this setting enabled unless you have a very large base and have specifically identified a bottleneck caused by it.
+cybersyn2-setting-constrain-coordinate-stop-direction=When enabled, the coordinate stops that control the train routing will have a direction set that forces the train to arrive in the same direction as the stop, even if the stop is on a bidirectional rail.\n\nUnchecking this can cause trains to arrive the wrong way to certain stations, so it is recommended to leave this checked unless you have a specific purpose in mind.
 
 [cybersyn2-alerts]
 no-station=Train stop has no station combinator.

--- a/mods/cybersyn2/scripts/logistics/delivery/train.lua
+++ b/mods/cybersyn2/scripts/logistics/delivery/train.lua
@@ -122,11 +122,17 @@ end
 ---@param stop_entity LuaEntity
 local function coordinate_entry(stop_entity)
 	---@type AddRecordData
-	local add = {
-		rail = stop_entity.connected_rail,
-		rail_direction = stop_entity.connected_rail_direction,
-	}
-	return add
+	if mod_settings.constrain_coordinate_stops then
+		return {
+			rail = stop_entity.connected_rail,
+			rail_direction = stop_entity.connected_rail_direction,
+		}
+	else
+		return {
+			rail = stop_entity.connected_rail,
+			rail_direction = nil,
+		}
+	end
 end
 
 ---@param conditions WaitCondition[]

--- a/mods/cybersyn2/scripts/settings.lua
+++ b/mods/cybersyn2/scripts/settings.lua
@@ -18,6 +18,7 @@ local strace = require("lib.core.strace")
 ---@field public default_train_fullness_fraction number Default train fullness threshold for deliveries, expressed as a fraction (0.0 to 1.0).
 ---@field public default_netmask int32 Default netmask.
 ---@field public shared_inventory_prefer_parallel boolean Whether to limit deliveries to shared inventory stations to one per cycle, to encourage parallelization across stations rather than queueing at a single station.
+---@field public constrain_coordinate_stops boolean Whether to set a direction when making coordinate stops to force them to arrive in the same direction as the train stop.
 
 ---@type Cybersyn.ModSettings
 ---@diagnostic disable-next-line: missing-fields
@@ -54,6 +55,8 @@ local function update_mod_settings()
 		settings.global["cybersyn2-setting-default-netmask"].value --[[@as int32]]
 	mod_settings.shared_inventory_prefer_parallel =
 		settings.global["cybersyn2-setting-shared-inventory-prefer-parallel"].value --[[@as boolean]]
+	mod_settings.constrain_coordinate_stops =
+		settings.global["cybersyn2-setting-constrain-coordinate-stop-direction"].value --[[@as boolean]]
 end
 _G.cs2.update_mod_settings = update_mod_settings
 

--- a/mods/cybersyn2/settings.lua
+++ b/mods/cybersyn2/settings.lua
@@ -111,4 +111,11 @@ data:extend({
 		setting_type = "runtime-global",
 		default_value = true,
 	},
+	{
+		type = "bool-setting",
+		name = "cybersyn2-setting-constrain-coordinate-stop-direction",
+		order = "ce",
+		setting_type = "runtime-global",
+		default_value = true,
+	},
 })


### PR DESCRIPTION
As discussed if the user doesn't change the default settings the code path is identical to before.

I used a mod setting instead of a combinator setting to avoid having to look up the combinator each time, but I'm happy to put the setting in the combinator instead.